### PR TITLE
2 patch hps java install

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -13,7 +13,8 @@ RUN mkdir ${__prefix}/hps &&\
       -Dcheckstyle.skip \
     &&\
     cp -t ${__prefix}/hps/java/ \
-      ~/.m2/repository/org/lcsim/lcio/2.7.4-SNAPSHOT/lcio-2.7.4-SNAPSHOT-bin.jar
+      ~/.m2/repository/org/lcsim/lcio/2.7.4-SNAPSHOT/lcio-2.7.4-SNAPSHOT-bin.jar &&\
+    find distribution/target -type f -name '*-bin.jar'
 ENV HPS_JAVA_BIN_JAR=${__prefix}/hps/java/distribution/target/hps-distribution-5.2.0-bin.jar
 
 # download and unpack fieldmaps

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir ${__prefix}/hps &&\
     &&\
     cp -t ${__prefix}/hps/java/ \
       ~/.m2/repository/org/lcsim/lcio/2.7.4-SNAPSHOT/lcio-2.7.4-SNAPSHOT-bin.jar
-ENV HPS_JAVA_BIN_JAR=${__prefix}/hps/java/distribution/target/hps-distribution-5.2-SNAPSHOT-bin.jar
+ENV HPS_JAVA_BIN_JAR=${__prefix}/hps/java/distribution/target/hps-distribution-5.2.0-bin.jar
 
 # download and unpack fieldmaps
 #   destination is chosen to be what is expected from hps-mc defaults

--- a/context/container.cfg
+++ b/context/container.cfg
@@ -3,7 +3,7 @@
 
 [DEFAULT]
 hpsmc_dir = /usr/local/
-hps_java_bin_jar = /usr/local/hps/java/distribution/target/hps-distribution-5.2-SNAPSHOT-bin.jar
+hps_java_bin_jar = /usr/local/hps/java/distribution/target/hps-distribution-5.2.0-bin.jar
 lcio_bin_jar = /usr/local/hps/java/lcio-2.7.4-SNAPSHOT-bin.jar
 detector_dir = /usr/local/hps/java/detector-data/detectors
 


### PR DESCRIPTION
This resolves #2 by updating the names for the hps-java jars to conform to the version we are building.

I also added a quick statement at the end of the hps-java build to printout all `*-bin.jar` files in the directory we just built so we can see what was built into the image (and how it was named) without having to download and open a container. Initial testing shows that this configuration is working, I am running a full-length test iDM 2019 job right now to make sure.